### PR TITLE
docs: add README and godoc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,160 @@
+# porter
+
+Authorization middleware, CSRF protection, and session settings for
+[Echo](https://echo.labstack.com). Works with or without an external auth
+provider (like [crooner](https://github.com/catgoose/crooner)).
+
+## Install
+
+```bash
+go get github.com/catgoose/porter
+```
+
+## CSRF Protection
+
+Porter ships a session-backed CSRF middleware. Any session store that satisfies
+`CSRFSessionStore` can hold the token -- crooner's `SessionManager`, a
+cookie-based store, or your own implementation.
+
+### Using the built-in cookie store
+
+```go
+e := echo.New()
+
+e.Use(porter.CSRF(porter.CookieCSRFStore{}, porter.CSRFConfig{}))
+```
+
+### Configuration
+
+```go
+e.Use(porter.CSRF(store, porter.CSRFConfig{
+    // Paths that skip CSRF validation entirely (login, OAuth callbacks).
+    ExemptPaths: []string{"/login", "/callback", "/logout"},
+
+    // Paths that get a fresh token on every GET (one-time-use forms).
+    PerRequestPaths: []string{"/transfer"},
+
+    // Rotate the token on every safe request, globally.
+    RotatePerRequest: false,
+}))
+```
+
+### Reading the token in templates
+
+The middleware sets the token on the echo context under `"csrf_token"`:
+
+```go
+e.GET("/form", func(c echo.Context) error {
+    token := c.Get("csrf_token").(string)
+    return c.Render(http.StatusOK, "form.html", map[string]any{
+        "CSRFToken": token,
+    })
+})
+```
+
+In your form:
+
+```html
+<form method="POST" action="/submit">
+    <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+    <!-- fields -->
+</form>
+```
+
+The middleware accepts the token from an `X-CSRF-Token` header or a `_csrf`
+form value.
+
+## Session Settings
+
+Porter provides per-session user preferences (theme, layout, etc.) backed by
+a `SessionSettingsProvider` repository.
+
+### Setup
+
+```go
+// repo implements porter.SessionSettingsProvider
+e.Use(porter.SessionSettingsMiddleware(repo, nil))
+```
+
+When the second argument (`SessionIDFunc`) is nil, porter generates a random
+cookie-based session ID automatically.
+
+### Reading settings in handlers
+
+```go
+e.GET("/dashboard", func(c echo.Context) error {
+    settings := porter.GetSessionSettings(c)
+    return c.Render(http.StatusOK, "dashboard.html", map[string]any{
+        "Theme":  settings.Theme,
+        "Layout": settings.Layout,
+    })
+})
+```
+
+## With Crooner
+
+[Crooner](https://github.com/catgoose/crooner) handles authentication (OIDC,
+OAuth2, session management). Porter layers on top for CSRF and session
+settings.
+
+### Wiring CSRF with crooner's session manager
+
+Crooner's `SessionManager` already satisfies `CSRFSessionStore`:
+
+```go
+sm := crooner.NewSessionManager(...)
+
+// Use crooner's session manager as the CSRF token store.
+e.Use(porter.CSRF(sm, porter.CSRFConfig{
+    ExemptPaths: []string{"/login", "/callback", "/logout"},
+}))
+```
+
+### Wiring session settings with crooner's session ID
+
+```go
+// Use crooner's session token as the session ID.
+e.Use(porter.SessionSettingsMiddleware(repo, func(c echo.Context) string {
+    return crooner.SessionID(c)
+}))
+```
+
+## Without Crooner
+
+For apps that do not need external authentication, porter works standalone:
+
+```go
+e := echo.New()
+
+// CSRF with the built-in cookie store.
+e.Use(porter.CSRF(porter.CookieCSRFStore{}, porter.CSRFConfig{}))
+
+// Session settings with auto-generated cookie IDs.
+e.Use(porter.SessionSettingsMiddleware(repo, nil))
+```
+
+## Architecture
+
+```
+┌──────────────────────────────────────┐
+│             HTTP Request             │
+└──────────────┬───────────────────────┘
+               │
+       ┌───────▼───────┐
+       │   crooner      │  "Who are you?"
+       │   (optional)   │  OIDC / OAuth2 / session login
+       └───────┬───────┘
+               │ identity on context
+       ┌───────▼───────┐
+       │   porter       │  "What can you do?"
+       │                │  CSRF · session settings · authorization
+       └───────┬───────┘
+               │
+       ┌───────▼───────┐
+       │   handler      │  Application logic
+       └───────────────┘
+```
+
+## License
+
+MIT

--- a/csrf.go
+++ b/csrf.go
@@ -1,3 +1,10 @@
+// Package porter provides authorization middleware, CSRF protection, and
+// session settings for Echo applications.
+//
+// Porter is designed around small interfaces so that each concern (session
+// storage, identity, authorization) can be satisfied by different backends.
+// Crooner's SessionManager, for example, directly satisfies [CSRFSessionStore],
+// but any implementation that can get and set string values will work.
 package porter
 
 import (
@@ -53,8 +60,17 @@ func (CookieCSRFStore) Set(c echo.Context, key string, value any) error {
 
 // CSRFConfig holds CSRF middleware configuration.
 type CSRFConfig struct {
-	PerRequestPaths  []string
-	ExemptPaths      []string
+	// PerRequestPaths lists URL paths that receive a fresh CSRF token on
+	// every safe (GET/HEAD/OPTIONS) request, useful for one-time-use forms.
+	PerRequestPaths []string
+
+	// ExemptPaths lists URL paths that skip CSRF validation entirely.
+	// Typically includes OAuth callback and logout endpoints.
+	ExemptPaths []string
+
+	// RotatePerRequest, when true, generates a new token on every safe
+	// request regardless of path. When false, the token is reused until
+	// a per-request path triggers rotation.
 	RotatePerRequest bool
 }
 

--- a/session.go
+++ b/session.go
@@ -15,8 +15,13 @@ const settingsContextKey = "sessionSettings"
 
 // SessionConfig holds session middleware configuration.
 type SessionConfig struct {
-	CookieName string       // defaults to "porter_session_id"
-	Logger     *slog.Logger // defaults to slog.Default()
+	// CookieName is the name of the cookie used to store the session ID.
+	// Defaults to "porter_session_id" when empty.
+	CookieName string
+
+	// Logger is used for error reporting during session loading.
+	// Defaults to slog.Default() when nil.
+	Logger *slog.Logger
 }
 
 func (cfg SessionConfig) cookieName() string {
@@ -33,8 +38,11 @@ func (cfg SessionConfig) logger() *slog.Logger {
 	return slog.Default()
 }
 
-// SessionSettingsProvider is the subset of session-settings operations that
-// the middleware needs: look up, create-or-update, and touch a row.
+// SessionSettingsProvider is the interface for session-settings persistence.
+// Implementations typically back this with a database table keyed on the
+// session UUID. The middleware calls [SessionSettingsProvider.GetByUUID] on
+// every request, [SessionSettingsProvider.Upsert] when creating defaults, and
+// [SessionSettingsProvider.Touch] to bump the timestamp once per day.
 type SessionSettingsProvider interface {
 	GetByUUID(ctx context.Context, uuid string) (*SessionSettings, error)
 	Upsert(ctx context.Context, s *SessionSettings) error
@@ -42,13 +50,18 @@ type SessionSettingsProvider interface {
 }
 
 // SessionIDFunc returns the session identifier for the current request.
-// When nil, the middleware falls back to a random cookie-based session ID.
+// Pass a function that extracts the session ID from an external auth provider
+// (e.g. crooner.SessionID). When nil or when the function returns an empty
+// string, the middleware falls back to a random cookie-based session ID.
 type SessionIDFunc func(c echo.Context) string
 
-// SessionSettingsMiddleware loads per-session settings and stores them on the
-// echo context. The session ID comes from idFunc (e.g. Crooner's SCS token).
-// When idFunc is nil or returns an empty string, the middleware falls back to
-// a random cookie-based session ID.
+// SessionSettingsMiddleware returns Echo middleware that loads per-session
+// settings and stores them on the echo context for downstream handlers.
+//
+// The session ID comes from idFunc (e.g. crooner's session token). When idFunc
+// is nil or returns an empty string, the middleware creates a random
+// cookie-based session ID automatically. Pass optional [SessionConfig] to
+// override the cookie name or logger.
 func SessionSettingsMiddleware(repo SessionSettingsProvider, idFunc SessionIDFunc, cfgs ...SessionConfig) echo.MiddlewareFunc {
 	var cfg SessionConfig
 	if len(cfgs) > 0 {

--- a/session_settings.go
+++ b/session_settings.go
@@ -2,20 +2,36 @@ package porter
 
 import "time"
 
-// SessionSettings holds user preferences keyed by a browser UUID cookie.
+// SessionSettings holds per-session user preferences keyed by a browser UUID
+// cookie. The struct is designed to be stored in a database row; the db tags
+// match the expected column names.
 type SessionSettings struct {
-	SessionUUID string    `db:"SessionUUID"`
-	Theme       string    `db:"Theme"`
-	Layout      string    `db:"Layout"`
-	UpdatedAt   time.Time `db:"UpdatedAt"`
-	ID          int       `db:"Id"`
+	// SessionUUID is the unique identifier tying these settings to a browser session.
+	SessionUUID string `db:"SessionUUID"`
+
+	// Theme is the UI color scheme (e.g. "light", "dark").
+	Theme string `db:"Theme"`
+
+	// Layout is the UI layout mode (e.g. "classic", "app").
+	Layout string `db:"Layout"`
+
+	// UpdatedAt tracks when the settings were last modified or touched.
+	UpdatedAt time.Time `db:"UpdatedAt"`
+
+	// ID is the database primary key.
+	ID int `db:"Id"`
 }
 
-// Default settings values.
+// Default settings values and layout constants.
 const (
-	DefaultTheme  = "light"
+	// DefaultTheme is the theme applied to new sessions.
+	DefaultTheme = "light"
+
+	// DefaultLayout is the layout applied to new sessions.
 	DefaultLayout = "classic"
-	LayoutApp     = "app"
+
+	// LayoutApp is the alternative "app" layout mode.
+	LayoutApp = "app"
 )
 
 // NewDefaultSettings returns a SessionSettings with defaults for the given UUID.


### PR DESCRIPTION
## Summary

- Add comprehensive README with install instructions, CSRF protection setup, session settings usage, crooner integration pattern, standalone usage, and architecture diagram
- Add godoc comments to all exported types, interfaces, functions, fields, and constants including package-level documentation

Closes #2
Closes #3