### PR TITLE
feat: add authorization interfaces and middleware

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,118 @@
+package porter
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// IdentityContextKey is the echo.Context key where authorization middleware
+// stores the resolved [Identity]. Use [GetIdentity] to retrieve it.
+const IdentityContextKey = "porter.identity"
+
+// Sentinel errors returned by authorization middleware and identity providers.
+var (
+	ErrNoIdentity      = errors.New("porter: no identity in context")
+	ErrInvalidIdentity = errors.New("porter: identity value is not a porter.Identity")
+	ErrForbidden       = errors.New("porter: forbidden")
+	ErrUnauthorized    = errors.New("porter: unauthorized")
+)
+
+// Identity represents an authenticated subject with roles.
+type Identity interface {
+	// Subject returns the unique identifier for this identity (user ID, email, etc.).
+	Subject() string
+	// Roles returns the roles assigned to this identity.
+	Roles() []string
+}
+
+// SimpleIdentity is a basic [Identity] implementation.
+type SimpleIdentity struct {
+	ID       string
+	RoleList []string
+}
+
+func (s SimpleIdentity) Subject() string { return s.ID }
+func (s SimpleIdentity) Roles() []string { return s.RoleList }
+
+// IdentityProvider extracts identity from a request context.
+// Crooner's session satisfies this; porter also ships [ContextIdentityProvider]
+// for reading identity set by external auth middleware.
+type IdentityProvider interface {
+	GetIdentity(c echo.Context) (Identity, error)
+}
+
+// ContextIdentityProvider reads identity from a key on [echo.Context].
+// Use this when your auth middleware (like crooner) stores identity on the context.
+type ContextIdentityProvider struct {
+	// ContextKey is the key used by auth middleware to store identity.
+	ContextKey string
+}
+
+func (p ContextIdentityProvider) GetIdentity(c echo.Context) (Identity, error) {
+	val := c.Get(p.ContextKey)
+	if val == nil {
+		return nil, ErrNoIdentity
+	}
+	id, ok := val.(Identity)
+	if !ok {
+		return nil, ErrInvalidIdentity
+	}
+	return id, nil
+}
+
+// GetIdentity retrieves the [Identity] from the echo context. Returns nil when
+// no identity has been set by authorization middleware.
+func GetIdentity(c echo.Context) Identity {
+	id, _ := c.Get(IdentityContextKey).(Identity)
+	return id
+}
+
+// RequireAuth returns middleware that rejects unauthenticated requests with
+// 401 Unauthorized. Authenticated identities are stored on the context at
+// [IdentityContextKey] for downstream handlers.
+func RequireAuth(provider IdentityProvider) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			id, err := provider.GetIdentity(c)
+			if err != nil || id == nil {
+				return c.NoContent(http.StatusUnauthorized)
+			}
+			c.Set(IdentityContextKey, id)
+			return next(c)
+		}
+	}
+}
+
+// RequireRole returns middleware that requires the identity to have the given
+// role. Unauthenticated requests receive 401; authenticated requests missing the
+// role receive 403.
+func RequireRole(provider IdentityProvider, role string) echo.MiddlewareFunc {
+	return RequireAnyRole(provider, role)
+}
+
+// RequireAnyRole returns middleware that requires the identity to have at least
+// one of the given roles. Unauthenticated requests receive 401; authenticated
+// requests missing all roles receive 403.
+func RequireAnyRole(provider IdentityProvider, roles ...string) echo.MiddlewareFunc {
+	want := make(map[string]struct{}, len(roles))
+	for _, r := range roles {
+		want[r] = struct{}{}
+	}
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			id, err := provider.GetIdentity(c)
+			if err != nil || id == nil {
+				return c.NoContent(http.StatusUnauthorized)
+			}
+			for _, r := range id.Roles() {
+				if _, ok := want[r]; ok {
+					c.Set(IdentityContextKey, id)
+					return next(c)
+				}
+			}
+			return c.NoContent(http.StatusForbidden)
+		}
+	}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,177 @@
+package porter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// staticProvider always returns the configured identity (or error).
+type staticProvider struct {
+	identity Identity
+	err      error
+}
+
+func (p *staticProvider) GetIdentity(echo.Context) (Identity, error) {
+	return p.identity, p.err
+}
+
+func newTestContext() (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+func TestRequireAuth_NoIdentity(t *testing.T) {
+	provider := &staticProvider{err: ErrNoIdentity}
+	mw := RequireAuth(provider)
+
+	c, rec := newTestContext()
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err := handler(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestRequireAuth_WithIdentity(t *testing.T) {
+	id := SimpleIdentity{ID: "user-1", RoleList: []string{"viewer"}}
+	provider := &staticProvider{identity: id}
+	mw := RequireAuth(provider)
+
+	c, rec := newTestContext()
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err := handler(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "ok", rec.Body.String())
+}
+
+func TestRequireRole_HasRole(t *testing.T) {
+	id := SimpleIdentity{ID: "user-1", RoleList: []string{"admin", "viewer"}}
+	provider := &staticProvider{identity: id}
+	mw := RequireRole(provider, "admin")
+
+	c, rec := newTestContext()
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err := handler(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRequireRole_MissingRole(t *testing.T) {
+	id := SimpleIdentity{ID: "user-1", RoleList: []string{"viewer"}}
+	provider := &staticProvider{identity: id}
+	mw := RequireRole(provider, "admin")
+
+	c, rec := newTestContext()
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err := handler(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestRequireAnyRole_HasOneOf(t *testing.T) {
+	id := SimpleIdentity{ID: "user-1", RoleList: []string{"editor"}}
+	provider := &staticProvider{identity: id}
+	mw := RequireAnyRole(provider, "admin", "editor")
+
+	c, rec := newTestContext()
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err := handler(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRequireAnyRole_HasNone(t *testing.T) {
+	id := SimpleIdentity{ID: "user-1", RoleList: []string{"viewer"}}
+	provider := &staticProvider{identity: id}
+	mw := RequireAnyRole(provider, "admin", "editor")
+
+	c, rec := newTestContext()
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err := handler(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestGetIdentity_FromContext(t *testing.T) {
+	id := SimpleIdentity{ID: "user-42", RoleList: []string{"admin"}}
+	provider := &staticProvider{identity: id}
+	mw := RequireAuth(provider)
+
+	c, _ := newTestContext()
+	handler := mw(func(c echo.Context) error {
+		got := GetIdentity(c)
+		require.NotNil(t, got)
+		require.Equal(t, "user-42", got.Subject())
+		require.Equal(t, []string{"admin"}, got.Roles())
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err := handler(c)
+	require.NoError(t, err)
+}
+
+func TestGetIdentity_NilWhenNotSet(t *testing.T) {
+	c, _ := newTestContext()
+	got := GetIdentity(c)
+	require.Nil(t, got)
+}
+
+func TestContextIdentityProvider(t *testing.T) {
+	provider := ContextIdentityProvider{ContextKey: "my_auth_identity"}
+
+	t.Run("reads identity from context", func(t *testing.T) {
+		c, _ := newTestContext()
+		id := SimpleIdentity{ID: "ctx-user", RoleList: []string{"member"}}
+		c.Set("my_auth_identity", id)
+
+		got, err := provider.GetIdentity(c)
+		require.NoError(t, err)
+		require.Equal(t, "ctx-user", got.Subject())
+		require.Equal(t, []string{"member"}, got.Roles())
+	})
+
+	t.Run("returns ErrNoIdentity when key is missing", func(t *testing.T) {
+		c, _ := newTestContext()
+		got, err := provider.GetIdentity(c)
+		require.ErrorIs(t, err, ErrNoIdentity)
+		require.Nil(t, got)
+	})
+
+	t.Run("returns ErrInvalidIdentity when value is wrong type", func(t *testing.T) {
+		c, _ := newTestContext()
+		c.Set("my_auth_identity", "not-an-identity")
+		got, err := provider.GetIdentity(c)
+		require.ErrorIs(t, err, ErrInvalidIdentity)
+		require.Nil(t, got)
+	})
+}
+
+// Compile-time interface checks.
+var (
+	_ Identity         = SimpleIdentity{}
+	_ IdentityProvider = ContextIdentityProvider{}
+)


### PR DESCRIPTION
## Summary

- Adds `Identity` interface and `SimpleIdentity` implementation for representing authenticated subjects with roles
- Adds `IdentityProvider` interface and `ContextIdentityProvider` for extracting identity from echo context (compatible with crooner session middleware)
- Adds `RequireAuth`, `RequireRole`, and `RequireAnyRole` middleware factories that enforce authentication/authorization with proper 401/403 responses
- Adds `GetIdentity` helper to retrieve the resolved identity from downstream handlers
- Defines sentinel errors (`ErrNoIdentity`, `ErrInvalidIdentity`, `ErrForbidden`, `ErrUnauthorized`)

## Test plan

- [x] TestRequireAuth_NoIdentity -- returns 401 when no identity is available
- [x] TestRequireAuth_WithIdentity -- passes through and stores identity on context
- [x] TestRequireRole_HasRole -- passes through when identity has the required role
- [x] TestRequireRole_MissingRole -- returns 403 when role is missing
- [x] TestRequireAnyRole_HasOneOf -- passes through when identity has one matching role
- [x] TestRequireAnyRole_HasNone -- returns 403 when no roles match
- [x] TestGetIdentity_FromContext -- retrieves stored identity after middleware runs
- [x] TestGetIdentity_NilWhenNotSet -- returns nil when no middleware has run
- [x] TestContextIdentityProvider -- reads identity from echo context key, handles missing/wrong type

Closes #4, closes #5