### PR TITLE
docs: add crooner integration guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,29 +94,224 @@ e.GET("/dashboard", func(c echo.Context) error {
 ## With Crooner
 
 [Crooner](https://github.com/catgoose/crooner) handles authentication (OIDC,
-OAuth2, session management). Porter layers on top for CSRF and session
-settings.
+OAuth2, session management). Porter layers on top for CSRF, session settings,
+and authorization. The two libraries share the same interface conventions, so
+wiring them together requires no adapters or glue code.
 
-### Wiring CSRF with crooner's session manager
+### Crooner's SessionManager satisfies CSRFSessionStore
 
-Crooner's `SessionManager` already satisfies `CSRFSessionStore`:
+Porter's CSRF middleware needs a `CSRFSessionStore`:
 
 ```go
-sm := crooner.NewSessionManager(...)
+type CSRFSessionStore interface {
+    Get(c echo.Context, key string) (any, error)
+    Set(c echo.Context, key string, value any) error
+}
+```
 
-// Use crooner's session manager as the CSRF token store.
+Crooner's `SessionManager` interface has the same `Get` and `Set` signatures,
+so any crooner session manager (`*SCSManager`, custom implementations, etc.)
+satisfies `CSRFSessionStore` directly -- no wrapper needed:
+
+```go
+sm, scsMgr, err := crooner.NewSCSManager(
+    crooner.WithPersistentCookieName(secret, "myapp"),
+    crooner.WithLifetime(12 * time.Hour),
+    crooner.WithStore(redisStore),
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+// sm satisfies porter.CSRFSessionStore -- pass it directly.
 e.Use(porter.CSRF(sm, porter.CSRFConfig{
     ExemptPaths: []string{"/login", "/callback", "/logout"},
 }))
 ```
 
-### Wiring session settings with crooner's session ID
+Both crooner and porter use the same session key (`"csrf_token"`) for the
+token, so tokens created by crooner's callback handler are validated by
+porter's CSRF middleware without any extra configuration.
+
+### Session settings with crooner's session ID
+
+Porter's `SessionSettingsMiddleware` accepts an optional `SessionIDFunc` that
+returns the session identifier for the current request. When crooner manages
+sessions, read the SCS token from the request so that session settings are
+tied to the authenticated session rather than a separate cookie:
 
 ```go
-// Use crooner's session token as the session ID.
+// Read the session token that SCS set on the request.
 e.Use(porter.SessionSettingsMiddleware(repo, func(c echo.Context) string {
-    return crooner.SessionID(c)
+    cookie, err := c.Cookie(sm.GetCookieName())
+    if err != nil || cookie.Value == "" {
+        return "" // falls back to porter's random cookie ID
+    }
+    return cookie.Value
 }))
+```
+
+When the function returns an empty string (no session cookie yet), porter
+automatically falls back to a random cookie-based session ID, so
+unauthenticated visitors still get session settings.
+
+### Bridging crooner's user info into porter's Identity
+
+Crooner stores the authenticated user in the session under the `"user"` key
+(and optionally additional claims via `SessionValueClaims`). Porter's
+authorization middleware expects an `IdentityProvider` that returns a
+`porter.Identity`.
+
+Use `ContextIdentityProvider` with a small middleware that reads from
+crooner's session and sets the identity on the context:
+
+```go
+// CroonerIdentityMiddleware reads the user and roles from crooner's session
+// and sets a porter.Identity on the echo context.
+func CroonerIdentityMiddleware(sm crooner.SessionManager) echo.MiddlewareFunc {
+    return func(next echo.HandlerFunc) echo.HandlerFunc {
+        return func(c echo.Context) error {
+            user, err := crooner.GetString(sm, c, crooner.SessionKeyUser)
+            if err != nil || user == "" {
+                return next(c) // no session user -- skip
+            }
+
+            // Read roles if stored via SessionValueClaims (e.g. "roles" claim).
+            var roles []string
+            if val, err := sm.Get(c, "roles"); err == nil {
+                if r, ok := val.([]string); ok {
+                    roles = r
+                }
+            }
+
+            c.Set("porter.user_identity", porter.SimpleIdentity{
+                ID:       user,
+                RoleList: roles,
+            })
+            return next(c)
+        }
+    }
+}
+```
+
+Then wire porter's authorization middleware with `ContextIdentityProvider`
+pointing at the same context key:
+
+```go
+idProvider := porter.ContextIdentityProvider{
+    ContextKey: "porter.user_identity",
+}
+
+// Protect all /admin routes -- requires authentication + "admin" role.
+admin := e.Group("/admin",
+    porter.RequireRole(idProvider, "admin"),
+)
+```
+
+### Complete wiring example
+
+```go
+package main
+
+import (
+    "log"
+    "time"
+
+    "github.com/catgoose/crooner"
+    "github.com/catgoose/porter"
+    "github.com/labstack/echo/v4"
+)
+
+func main() {
+    e := echo.New()
+
+    // -- crooner: session + OIDC auth --
+
+    sm, scsMgr, err := crooner.NewSCSManager(
+        crooner.WithPersistentCookieName("secret", "myapp"),
+        crooner.WithLifetime(12 * time.Hour),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    e.Use(echo.WrapMiddleware(scsMgr.LoadAndSave))
+
+    // crooner.NewAuthConfig sets up /login, /callback, /logout and
+    // the RequireAuth middleware that redirects unauthenticated users.
+    // See crooner's README for full AuthConfigParams.
+
+    // -- porter: CSRF --
+
+    // sm satisfies porter.CSRFSessionStore directly.
+    e.Use(porter.CSRF(sm, porter.CSRFConfig{
+        ExemptPaths: []string{"/login", "/callback", "/logout"},
+    }))
+
+    // -- porter: session settings --
+
+    // repo implements porter.SessionSettingsProvider (backed by your DB).
+    var repo porter.SessionSettingsProvider
+    e.Use(porter.SessionSettingsMiddleware(repo, func(c echo.Context) string {
+        cookie, err := c.Cookie(sm.GetCookieName())
+        if err != nil || cookie.Value == "" {
+            return ""
+        }
+        return cookie.Value
+    }))
+
+    // -- porter: authorization --
+
+    // Bridge crooner's session user into porter's Identity.
+    e.Use(CroonerIdentityMiddleware(sm))
+
+    idProvider := porter.ContextIdentityProvider{
+        ContextKey: "porter.user_identity",
+    }
+
+    // Public routes.
+    e.GET("/", homeHandler)
+
+    // Authenticated routes.
+    e.GET("/dashboard", dashboardHandler,
+        porter.RequireAuth(idProvider),
+    )
+
+    // Role-protected routes.
+    admin := e.Group("/admin",
+        porter.RequireRole(idProvider, "admin"),
+    )
+    admin.GET("", adminHandler)
+
+    e.Logger.Fatal(e.Start(":8080"))
+}
+
+// CroonerIdentityMiddleware reads the user and roles from crooner's session
+// and sets a porter.Identity on the echo context.
+func CroonerIdentityMiddleware(sm crooner.SessionManager) echo.MiddlewareFunc {
+    return func(next echo.HandlerFunc) echo.HandlerFunc {
+        return func(c echo.Context) error {
+            user, err := crooner.GetString(sm, c, crooner.SessionKeyUser)
+            if err != nil || user == "" {
+                return next(c)
+            }
+            var roles []string
+            if val, err := sm.Get(c, "roles"); err == nil {
+                if r, ok := val.([]string); ok {
+                    roles = r
+                }
+            }
+            c.Set("porter.user_identity", porter.SimpleIdentity{
+                ID:       user,
+                RoleList: roles,
+            })
+            return next(c)
+        }
+    }
+}
+
+func homeHandler(c echo.Context) error      { return c.String(200, "home") }
+func dashboardHandler(c echo.Context) error  { return c.String(200, "dashboard") }
+func adminHandler(c echo.Context) error      { return c.String(200, "admin") }
 ```
 
 ## Without Crooner


### PR DESCRIPTION
Closes #6

Expands the "With Crooner" section to cover the four integration seams:

- **CSRFSessionStore**: crooner's `SessionManager` satisfies the interface directly, no adapter needed. Both use the same `"csrf_token"` session key.
- **SessionSettingsMiddleware**: reads crooner's SCS cookie via `sm.GetCookieName()` to tie session settings to the authenticated session.
- **Identity bridging**: a `CroonerIdentityMiddleware` reads user/roles from crooner's session and sets a `porter.SimpleIdentity` on the context for `ContextIdentityProvider`.
- **Complete wiring example**: a full `main.go` showing crooner + porter configured together with CSRF, session settings, and role-based authorization.