### PR TITLE
docs: add screenshot to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/catgoose/porter.svg)](https://pkg.go.dev/github.com/catgoose/porter)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+![porter](https://raw.githubusercontent.com/catgoose/screenshots/main/porter/porter.png)
+
 Authorization middleware, CSRF protection, and session settings for
 [Echo](https://echo.labstack.com). Works with or without an external auth
 provider (like [crooner](https://github.com/catgoose/crooner)).


### PR DESCRIPTION
## Summary
- Add screenshot image after badges in README, hosted from catgoose/screenshots repo