### PR TITLE
fix: handle unchecked return values in test files

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -27,7 +27,7 @@ func TestRequireAuth_NoIdentity(t *testing.T) {
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -45,7 +45,7 @@ func TestRequireAuth_WithIdentity(t *testing.T) {
 
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -63,7 +63,7 @@ func TestRequireRole_HasRole(t *testing.T) {
 
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -80,7 +80,7 @@ func TestRequireRole_MissingRole(t *testing.T) {
 
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -97,7 +97,7 @@ func TestRequireAnyRole_HasOneOf(t *testing.T) {
 
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -114,7 +114,7 @@ func TestRequireAnyRole_HasNone(t *testing.T) {
 
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -135,7 +135,7 @@ func TestGetIdentity_FromContext(t *testing.T) {
 		require.Equal(t, "user-42", got.Subject())
 		require.Equal(t, []string{"admin"}, got.Roles())
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/example_test.go
+++ b/example_test.go
@@ -37,7 +37,7 @@ func ExampleSessionSettingsMiddleware() {
 	handler := porter.SessionSettingsMiddleware(repo, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s := porter.GetSessionSettings(r)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "theme=%s layout=%s", s.Theme, s.Layout)
+		_, _ = fmt.Fprintf(w, "theme=%s layout=%s", s.Theme, s.Layout)
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -60,7 +60,7 @@ func ExampleSessionSettingsMiddleware_customConfig() {
 	handler := porter.SessionSettingsMiddleware(repo, nil, cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s := porter.GetSessionSettings(r)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "theme=%s", s.Theme)
+		_, _ = fmt.Fprintf(w, "theme=%s", s.Theme)
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -84,7 +84,7 @@ func ExampleSessionSettingsMiddleware_withIDFunc() {
 	handler := porter.SessionSettingsMiddleware(repo, idFunc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s := porter.GetSessionSettings(r)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "uuid=%s theme=%s", s.SessionUUID, s.Theme)
+		_, _ = fmt.Fprintf(w, "uuid=%s theme=%s", s.SessionUUID, s.Theme)
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -104,7 +104,7 @@ func ExampleGetSessionSettings() {
 	handler := porter.SessionSettingsMiddleware(repo, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s := porter.GetSessionSettings(r)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(s.Theme))
+		_, _ = w.Write([]byte(s.Theme))
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)


### PR DESCRIPTION
## Summary

- Assign `w.Write` return values to blank identifiers in `auth_test.go` (7 occurrences)
- Assign `fmt.Fprintf` return values to blank identifiers in `example_test.go` (3 occurrences)
- Assign `w.Write` return value to blank identifier in `example_test.go` (1 occurrence)

Fixes errcheck lint failures in CI.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes