### PR TITLE
feat: add RequireAllRoles middleware

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -92,6 +92,37 @@ func RequireRole(provider IdentityProvider, role string) func(http.Handler) http
 	return RequireAnyRole(provider, role)
 }
 
+// RequireAllRoles returns middleware that requires the identity to have all of
+// the given roles. Unauthenticated requests receive 401; authenticated requests
+// missing any role receive 403.
+func RequireAllRoles(provider IdentityProvider, roles ...string) func(http.Handler) http.Handler {
+	want := make(map[string]struct{}, len(roles))
+	for _, r := range roles {
+		want[r] = struct{}{}
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id, err := provider.GetIdentity(r)
+			if err != nil || id == nil {
+				http.Error(w, "", http.StatusUnauthorized)
+				return
+			}
+			have := make(map[string]struct{}, len(id.Roles()))
+			for _, role := range id.Roles() {
+				have[role] = struct{}{}
+			}
+			for needed := range want {
+				if _, ok := have[needed]; !ok {
+					http.Error(w, "", http.StatusForbidden)
+					return
+				}
+			}
+			r = r.WithContext(context.WithValue(r.Context(), identityCtxKey, id))
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // RequireAnyRole returns middleware that requires the identity to have at least
 // one of the given roles. Unauthenticated requests receive 401; authenticated
 // requests missing all roles receive 403.

--- a/auth_test.go
+++ b/auth_test.go
@@ -204,6 +204,64 @@ func TestRequireAnyRole_NilIdentityNoError(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
+func TestRequireAllRoles(t *testing.T) {
+	ok := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	tests := []struct {
+		name     string
+		provider *staticProvider
+		roles    []string
+		wantCode int
+	}{
+		{
+			name:     "has all roles",
+			provider: &staticProvider{identity: SimpleIdentity{ID: "u1", RoleList: []string{"admin", "editor", "viewer"}}},
+			roles:    []string{"admin", "editor"},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "missing one role",
+			provider: &staticProvider{identity: SimpleIdentity{ID: "u1", RoleList: []string{"editor"}}},
+			roles:    []string{"admin", "editor"},
+			wantCode: http.StatusForbidden,
+		},
+		{
+			name:     "no identity returns 401",
+			provider: &staticProvider{err: ErrNoIdentity},
+			roles:    []string{"admin"},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "nil identity no error returns 401",
+			provider: &staticProvider{identity: nil, err: nil},
+			roles:    []string{"admin"},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "empty roles list allows any authenticated user",
+			provider: &staticProvider{identity: SimpleIdentity{ID: "u1", RoleList: []string{"viewer"}}},
+			roles:    []string{},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mw := RequireAllRoles(tt.provider, tt.roles...)
+			handler := mw(ok)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			require.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+}
+
 // Compile-time interface checks.
 var (
 	_ Identity         = SimpleIdentity{}


### PR DESCRIPTION
## Summary

- Adds `RequireAllRoles` middleware to `auth.go` that requires ALL specified roles (AND logic), complementing the existing `RequireAnyRole` (OR logic)
- Returns 401 for unauthenticated requests, 403 when any required role is missing
- Table-driven tests cover: all roles present (200), missing one role (403), no identity (401), nil identity (401), and empty roles list (200)

Closes #23

## Test plan

- [x] `make` passes (vet + tests with race detector)
- [x] All five `TestRequireAllRoles` subtests pass
- [x] Existing tests unaffected