### PR TITLE
feat: add custom error handlers for auth middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ when the identity lacks the required role(s):
 adminOnly := porter.RequireRole(provider, "admin")
 handler := adminOnly(mux)
 
-editorOrAdmin := porter.RequireAnyRole(provider, "admin", "editor")
+editorOrAdmin := porter.RequireAnyRole(provider, []string{"admin", "editor"})
 handler := editorOrAdmin(mux)
 ```
 

--- a/auth.go
+++ b/auth.go
@@ -68,15 +68,55 @@ func GetIdentity(r *http.Request) Identity {
 	return id
 }
 
+// AuthErrorFunc is a callback invoked when auth middleware rejects a request.
+// The err argument is one of the sentinel errors ([ErrUnauthorized] or
+// [ErrForbidden]) so callers can distinguish 401 vs 403 cases.
+type AuthErrorFunc func(w http.ResponseWriter, r *http.Request, err error)
+
+// AuthOption configures optional behavior for auth middleware.
+type AuthOption func(*authConfig)
+
+type authConfig struct {
+	errorHandler AuthErrorFunc
+}
+
+func buildAuthConfig(opts []AuthOption) authConfig {
+	var cfg authConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return cfg
+}
+
+// AuthErrorHandler returns an [AuthOption] that sets a custom error handler
+// for auth middleware. When set, the handler is called instead of the default
+// bare status-code response.
+func AuthErrorHandler(fn AuthErrorFunc) AuthOption {
+	return func(cfg *authConfig) {
+		cfg.errorHandler = fn
+	}
+}
+
+// authFail writes the appropriate error response. If a custom handler is
+// configured it delegates to that; otherwise it writes a bare status code.
+func authFail(w http.ResponseWriter, r *http.Request, err error, statusCode int, cfg authConfig) {
+	if cfg.errorHandler != nil {
+		cfg.errorHandler(w, r, err)
+		return
+	}
+	http.Error(w, "", statusCode)
+}
+
 // RequireAuth returns middleware that rejects unauthenticated requests with
 // 401 Unauthorized. Authenticated identities are stored on the request context
 // for downstream handlers via [GetIdentity].
-func RequireAuth(provider IdentityProvider) func(http.Handler) http.Handler {
+func RequireAuth(provider IdentityProvider, opts ...AuthOption) func(http.Handler) http.Handler {
+	cfg := buildAuthConfig(opts)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			id, err := provider.GetIdentity(r)
 			if err != nil || id == nil {
-				http.Error(w, "", http.StatusUnauthorized)
+				authFail(w, r, ErrUnauthorized, http.StatusUnauthorized, cfg)
 				return
 			}
 			r = r.WithContext(context.WithValue(r.Context(), identityCtxKey, id))
@@ -88,14 +128,15 @@ func RequireAuth(provider IdentityProvider) func(http.Handler) http.Handler {
 // RequireRole returns middleware that requires the identity to have the given
 // role. Unauthenticated requests receive 401; authenticated requests missing the
 // role receive 403.
-func RequireRole(provider IdentityProvider, role string) func(http.Handler) http.Handler {
-	return RequireAnyRole(provider, role)
+func RequireRole(provider IdentityProvider, role string, opts ...AuthOption) func(http.Handler) http.Handler {
+	return RequireAnyRole(provider, []string{role}, opts...)
 }
 
 // RequireAnyRole returns middleware that requires the identity to have at least
 // one of the given roles. Unauthenticated requests receive 401; authenticated
 // requests missing all roles receive 403.
-func RequireAnyRole(provider IdentityProvider, roles ...string) func(http.Handler) http.Handler {
+func RequireAnyRole(provider IdentityProvider, roles []string, opts ...AuthOption) func(http.Handler) http.Handler {
+	cfg := buildAuthConfig(opts)
 	want := make(map[string]struct{}, len(roles))
 	for _, r := range roles {
 		want[r] = struct{}{}
@@ -104,7 +145,7 @@ func RequireAnyRole(provider IdentityProvider, roles ...string) func(http.Handle
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			id, err := provider.GetIdentity(r)
 			if err != nil || id == nil {
-				http.Error(w, "", http.StatusUnauthorized)
+				authFail(w, r, ErrUnauthorized, http.StatusUnauthorized, cfg)
 				return
 			}
 			for _, role := range id.Roles() {
@@ -114,7 +155,7 @@ func RequireAnyRole(provider IdentityProvider, roles ...string) func(http.Handle
 					return
 				}
 			}
-			http.Error(w, "", http.StatusForbidden)
+			authFail(w, r, ErrForbidden, http.StatusForbidden, cfg)
 		})
 	}
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -93,7 +93,7 @@ func TestRequireRole_MissingRole(t *testing.T) {
 func TestRequireAnyRole_HasOneOf(t *testing.T) {
 	id := SimpleIdentity{ID: "user-1", RoleList: []string{"editor"}}
 	provider := &staticProvider{identity: id}
-	mw := RequireAnyRole(provider, "admin", "editor")
+	mw := RequireAnyRole(provider, []string{"admin", "editor"})
 
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -110,7 +110,7 @@ func TestRequireAnyRole_HasOneOf(t *testing.T) {
 func TestRequireAnyRole_HasNone(t *testing.T) {
 	id := SimpleIdentity{ID: "user-1", RoleList: []string{"viewer"}}
 	provider := &staticProvider{identity: id}
-	mw := RequireAnyRole(provider, "admin", "editor")
+	mw := RequireAnyRole(provider, []string{"admin", "editor"})
 
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -188,7 +188,7 @@ func TestContextIdentityProvider(t *testing.T) {
 // returns nil identity with no error, which should result in 401.
 func TestRequireAnyRole_NilIdentityNoError(t *testing.T) {
 	provider := &staticProvider{identity: nil, err: nil}
-	mw := RequireAnyRole(provider, "admin")
+	mw := RequireAnyRole(provider, []string{"admin"})
 
 	var called bool
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -202,6 +202,135 @@ func TestRequireAnyRole_NilIdentityNoError(t *testing.T) {
 
 	require.False(t, called)
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestAuthErrorHandler_RequireAuth(t *testing.T) {
+	provider := &staticProvider{err: ErrNoIdentity}
+
+	var gotErr error
+	handler := RequireAuth(provider, AuthErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
+		gotErr = err
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("please log in"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, req)
+
+	require.ErrorIs(t, gotErr, ErrUnauthorized)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Equal(t, "please log in", rec.Body.String())
+}
+
+func TestAuthErrorHandler_RequireRole_Forbidden(t *testing.T) {
+	id := SimpleIdentity{ID: "user-1", RoleList: []string{"viewer"}}
+	provider := &staticProvider{identity: id}
+
+	var gotErr error
+	handler := RequireRole(provider, "admin", AuthErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
+		gotErr = err
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("no access"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, req)
+
+	require.ErrorIs(t, gotErr, ErrForbidden)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, "no access", rec.Body.String())
+}
+
+func TestAuthErrorHandler_RequireRole_Unauthorized(t *testing.T) {
+	provider := &staticProvider{err: ErrNoIdentity}
+
+	var gotErr error
+	handler := RequireRole(provider, "admin", AuthErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
+		gotErr = err
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("login required"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, req)
+
+	require.ErrorIs(t, gotErr, ErrUnauthorized)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Equal(t, "login required", rec.Body.String())
+}
+
+func TestAuthErrorHandler_RequireAnyRole(t *testing.T) {
+	id := SimpleIdentity{ID: "user-1", RoleList: []string{"viewer"}}
+	provider := &staticProvider{identity: id}
+
+	var gotErr error
+	handler := RequireAnyRole(provider, []string{"admin", "editor"}, AuthErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
+		gotErr = err
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("insufficient role"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, req)
+
+	require.ErrorIs(t, gotErr, ErrForbidden)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, "insufficient role", rec.Body.String())
+}
+
+func TestAuthErrorHandler_DefaultBehaviorUnchanged(t *testing.T) {
+	t.Run("RequireAuth without options", func(t *testing.T) {
+		provider := &staticProvider{err: ErrNoIdentity}
+		mw := RequireAuth(provider)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("RequireRole without options", func(t *testing.T) {
+		id := SimpleIdentity{ID: "user-1", RoleList: []string{"viewer"}}
+		provider := &staticProvider{identity: id}
+		mw := RequireRole(provider, "admin")
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("RequireAnyRole without options", func(t *testing.T) {
+		id := SimpleIdentity{ID: "user-1", RoleList: []string{"viewer"}}
+		provider := &staticProvider{identity: id}
+		mw := RequireAnyRole(provider, []string{"admin"})
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusForbidden, rec.Code)
+	})
 }
 
 // Compile-time interface checks.


### PR DESCRIPTION
## Summary

- Adds `AuthErrorFunc` callback type and `AuthErrorHandler` functional option for `RequireAuth`, `RequireRole`, and `RequireAnyRole` middleware, allowing users to customize 401/403 responses (e.g., redirect to login, return HTML)
- Changes `RequireAnyRole` signature from variadic `roles ...string` to `roles []string` to avoid ambiguity with the options variadic parameter
- Default behavior (bare status codes, empty body) is preserved when no error handler option is provided

## Test plan

- [x] Custom error handler receives `ErrUnauthorized` for unauthenticated requests via `RequireAuth`
- [x] Custom error handler receives `ErrForbidden` for unauthorized requests via `RequireRole`
- [x] Custom error handler receives `ErrUnauthorized` for unauthenticated requests via `RequireRole`
- [x] Custom error handler receives `ErrForbidden` for unauthorized requests via `RequireAnyRole`
- [x] Custom error handler can write custom response body and status code
- [x] Default behavior unchanged when no options provided (all three functions)
- [x] All existing tests pass with updated signatures
- [x] `go vet` clean