### PR TITLE
feat: make HSTS opt-in, add DefaultHSTSConfig helper

### DIFF
--- a/headers.go
+++ b/headers.go
@@ -46,16 +46,23 @@ type HSTSConfig struct {
 }
 
 // DefaultSecurityHeadersConfig returns a [SecurityHeadersConfig] with sensible defaults.
+// HSTS is nil (disabled) by default because it can break development environments
+// without TLS. Enable it explicitly with [DefaultHSTSConfig] when serving over HTTPS.
 func DefaultSecurityHeadersConfig() SecurityHeadersConfig {
 	return SecurityHeadersConfig{
 		XFrameOptions:           "SAMEORIGIN",
 		XContentTypeOptions:     "nosniff",
 		XXSSProtection:          "0",
 		ReferrerPolicy:          "strict-origin-when-cross-origin",
-		HSTS:                    &HSTSConfig{MaxAge: 63072000, IncludeSubDomains: true},
 		PermissionsPolicy:       "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
 		CrossOriginOpenerPolicy: "same-origin",
 	}
+}
+
+// DefaultHSTSConfig returns an [HSTSConfig] with sensible defaults:
+// max-age=63072000 (2 years), includeSubDomains=true, preload=false.
+func DefaultHSTSConfig() *HSTSConfig {
+	return &HSTSConfig{MaxAge: 63072000, IncludeSubDomains: true}
 }
 
 // SecurityHeaders returns middleware that sets security response headers before

--- a/headers_test.go
+++ b/headers_test.go
@@ -27,7 +27,7 @@ func TestSecurityHeaders_NoArgs_UsesDefaults(t *testing.T) {
 	require.Equal(t, "nosniff", h.Get("X-Content-Type-Options"))
 	require.Equal(t, "0", h.Get("X-XSS-Protection"))
 	require.Equal(t, "strict-origin-when-cross-origin", h.Get("Referrer-Policy"))
-	require.Equal(t, "max-age=63072000; includeSubDomains", h.Get("Strict-Transport-Security"))
+	require.Empty(t, h.Get("Strict-Transport-Security"), "HSTS should be disabled by default")
 	require.Equal(t, "camera=(), microphone=(), geolocation=(), payment=(), usb=()", h.Get("Permissions-Policy"))
 	require.Equal(t, "same-origin", h.Get("Cross-Origin-Opener-Policy"))
 	require.Empty(t, h.Get("Content-Security-Policy"))
@@ -40,7 +40,7 @@ func TestSecurityHeaders_DefaultConfig_SetsAllExpectedHeaders(t *testing.T) {
 	require.Equal(t, "nosniff", h.Get("X-Content-Type-Options"))
 	require.Equal(t, "0", h.Get("X-XSS-Protection"))
 	require.Equal(t, "strict-origin-when-cross-origin", h.Get("Referrer-Policy"))
-	require.Equal(t, "max-age=63072000; includeSubDomains", h.Get("Strict-Transport-Security"))
+	require.Empty(t, h.Get("Strict-Transport-Security"), "HSTS should be disabled by default")
 	require.Equal(t, "camera=(), microphone=(), geolocation=(), payment=(), usb=()", h.Get("Permissions-Policy"))
 	require.Equal(t, "same-origin", h.Get("Cross-Origin-Opener-Policy"))
 }
@@ -85,9 +85,9 @@ func TestSecurityHeaders_HSTS_Nil_OmitsHeader(t *testing.T) {
 	require.Empty(t, h.Get("Strict-Transport-Security"))
 }
 
-func TestSecurityHeaders_HSTS_Defaults(t *testing.T) {
+func TestSecurityHeaders_HSTS_OptIn_WithDefaultHSTSConfig(t *testing.T) {
 	cfg := DefaultSecurityHeadersConfig()
-	// HSTS defaults: MaxAge=63072000, IncludeSubDomains=true, Preload=false.
+	cfg.HSTS = DefaultHSTSConfig()
 
 	h := runSecurityHeaders(t, SecurityHeaders(cfg))
 
@@ -145,7 +145,7 @@ func TestSecurityHeaders_HeadersPresentOnResponse(t *testing.T) {
 	require.Equal(t, "hello", rec.Body.String())
 	require.NotEmpty(t, rec.Header().Get("X-Frame-Options"))
 	require.NotEmpty(t, rec.Header().Get("X-Content-Type-Options"))
-	require.NotEmpty(t, rec.Header().Get("Strict-Transport-Security"))
+	require.Empty(t, rec.Header().Get("Strict-Transport-Security"), "HSTS should be disabled by default")
 }
 
 func TestSecurityHeaders_ZeroValueHSTSMaxAge_UsesDefault(t *testing.T) {


### PR DESCRIPTION
## Summary

- Make HSTS disabled by default in `DefaultSecurityHeadersConfig()` — it can break dev environments without TLS
- Add `DefaultHSTSConfig()` helper for easy opt-in: `cfg.HSTS = DefaultHSTSConfig()`
- `X-Content-Type-Options: nosniff` was already present and enabled by default — no change needed

Closes #36