### PR TITLE
feat: Sec-Fetch-Site fast-path in CSRFProtect

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -273,6 +273,43 @@ func CSRFProtect(cfg CSRFConfig) func(http.Handler) http.Handler {
 					}
 				}
 			} else {
+				// Sec-Fetch-Site fast path: modern browsers that send
+				// "same-origin" guarantee the request came from this origin,
+				// so we can skip the token dance entirely.  We still set the
+				// cookie and context masker so forms/GetToken keep working.
+				if r.Header.Get("Sec-Fetch-Site") == "same-origin" {
+					// Reuse existing cookie nonce or generate a fresh one.
+					if c, err := r.Cookie(cfg.CookieName); err == nil && c.Value != "" {
+						nonce = c.Value
+					} else {
+						n, err := generateNonce()
+						if err != nil {
+							http.Error(w, "", http.StatusInternalServerError)
+							return
+						}
+						nonce = n
+					}
+
+					http.SetCookie(w, &http.Cookie{
+						Name:     cfg.CookieName,
+						Value:    nonce,
+						Path:     cfg.CookiePath,
+						MaxAge:   cfg.MaxAge,
+						Secure:   !cfg.InsecureCookie,
+						HttpOnly: true,
+						SameSite: cfg.SameSite,
+					})
+
+					tokenBytes := computeHMAC(nonce)
+					r = r.WithContext(context.WithValue(r.Context(), csrfTokenCtxKey, &csrfMasker{
+						tokenBytes: tokenBytes,
+						mask:       maskToken,
+					}))
+
+					next.ServeHTTP(w, r)
+					return
+				}
+
 				// Unsafe method: validate Origin header if configured.
 				if cfg.ValidateOrigin && !checkOrigin(r) {
 					fail(w, r)

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -745,3 +745,93 @@ func TestPOST_WithValidToken_AfterRotatePerRequest(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, postRec.Code)
 }
+
+// TestSecFetch_SameOrigin_SkipsTokenValidation verifies that a POST with
+// Sec-Fetch-Site: same-origin succeeds without a CSRF token.
+func TestSecFetch_SameOrigin_SkipsTokenValidation(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CSRFProtect(minimalCfg())(inner)
+
+	rec := doRequest(t, handler, http.MethodPost, "/", func(r *http.Request) {
+		r.Header.Set("Sec-Fetch-Site", "same-origin")
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestSecFetch_CrossSite_StillRequiresToken verifies that Sec-Fetch-Site:
+// cross-site does NOT bypass token validation.
+func TestSecFetch_CrossSite_StillRequiresToken(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CSRFProtect(minimalCfg())(inner)
+
+	rec := doRequest(t, handler, http.MethodPost, "/", func(r *http.Request) {
+		r.Header.Set("Sec-Fetch-Site", "cross-site")
+	})
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestSecFetch_SameSite_StillRequiresToken verifies that Sec-Fetch-Site:
+// same-site does NOT bypass token validation.
+func TestSecFetch_SameSite_StillRequiresToken(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CSRFProtect(minimalCfg())(inner)
+
+	rec := doRequest(t, handler, http.MethodPost, "/", func(r *http.Request) {
+		r.Header.Set("Sec-Fetch-Site", "same-site")
+	})
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestSecFetch_None_StillRequiresToken verifies that Sec-Fetch-Site: none
+// does NOT bypass token validation.
+func TestSecFetch_None_StillRequiresToken(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CSRFProtect(minimalCfg())(inner)
+
+	rec := doRequest(t, handler, http.MethodPost, "/", func(r *http.Request) {
+		r.Header.Set("Sec-Fetch-Site", "none")
+	})
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestSecFetch_Absent_StillRequiresToken verifies that a POST without any
+// Sec-Fetch-Site header still requires a valid CSRF token.
+func TestSecFetch_Absent_StillRequiresToken(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CSRFProtect(minimalCfg())(inner)
+
+	rec := doRequest(t, handler, http.MethodPost, "/", nil)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestSecFetch_SameOrigin_SetsCookieAndContext verifies that the fast path
+// still sets the CSRF cookie and makes GetToken() work.
+func TestSecFetch_SameOrigin_SetsCookieAndContext(t *testing.T) {
+	var contextToken string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contextToken = GetToken(r)
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CSRFProtect(minimalCfg())(inner)
+
+	rec := doRequest(t, handler, http.MethodPost, "/", func(r *http.Request) {
+		r.Header.Set("Sec-Fetch-Site", "same-origin")
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotEmpty(t, contextToken, "GetToken should return a token on same-origin fast path")
+
+	cookie := extractCookie(rec, "_csrf")
+	require.NotNil(t, cookie, "CSRF cookie should be set on same-origin fast path")
+	require.NotEmpty(t, cookie.Value)
+}


### PR DESCRIPTION
## Summary

- When `Sec-Fetch-Site: same-origin` is present on unsafe methods, skip token validation entirely (browser guarantees same-origin)
- All other header values and absent headers fall through to existing token validation unchanged
- Cookie and context masker still set on fast path so `GetToken()` and forms keep working
- No new config fields — transparent optimization for modern browsers (94%+ coverage)

Closes #34