### PR TITLE
docs: document Sec-Fetch-Site CSRF fast-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ token := porter.GetToken(r)
 1. Every request gets a cookie containing a random nonce
 2. The CSRF token is `HMAC-SHA256(key, nonce)`, stored on the request context
 3. Safe methods (GET, HEAD, OPTIONS) set the cookie and context but skip validation
-4. Unsafe methods (POST, PUT, PATCH, DELETE) validate: the submitted token must
-   match the expected HMAC -- checked from the request header first, then the form field
+4. Unsafe methods with `Sec-Fetch-Site: same-origin` skip token validation entirely -- the browser guarantees the request originated from the same origin (94%+ browser coverage)
+5. All other unsafe methods validate: the submitted token must match the expected HMAC -- checked from the request header first, then the form field
 
 ### Configuration
 


### PR DESCRIPTION
## Summary

- Add Sec-Fetch-Site fast-path to the CSRF "How it works" section
- Documents the transparent optimization shipped in PR #40