### PR TITLE
fix: remove unnecessary type assertion (staticcheck S1040)

### DIFF
--- a/body.go
+++ b/body.go
@@ -43,7 +43,7 @@ func (m *maxBodyWriter) WriteHeader(code int) {
 
 func (m *maxBodyWriter) Write(b []byte) (int, error) {
 	if m.intercepted {
-		return io.Discard.(io.Writer).Write(b)
+		return io.Discard.Write(b)
 	}
 	return m.ResponseWriter.Write(b)
 }


### PR DESCRIPTION
## Summary

- Remove unnecessary `io.Discard.(io.Writer)` type assertion in `body.go` line 46
- `io.Discard` is already an `io.Writer`, so the assertion is redundant and triggers staticcheck S1040