### PR TITLE
feat: add rate limiting and brute force protection middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@
 > -- The Wisdom of the Uniform Interface
 
 Post-authentication security middleware for Go `net/http` applications. Porter
-guards the door -- role enforcement, CSRF verification, request limits, and
-response hardening in standard `func(http.Handler) http.Handler` middleware.
+guards the door -- role enforcement, CSRF verification, rate limiting, request
+limits, and response hardening in standard `func(http.Handler) http.Handler`
+middleware.
 Porter doesn't handle authentication (see [crooner](https://github.com/catgoose/crooner)
 for that) -- it assumes an identity already exists and enforces security on top
 of it.
@@ -342,6 +343,108 @@ limit := porter.MaxRequestBody(porter.MaxBodyConfig{
 })
 ```
 
+## Rate Limiting
+
+> grug brain no want million request per second.
+>
+> -- Layman Grug
+
+Fixed-window rate limiting with per-path overrides, custom key functions, and
+exemptions. No external dependencies -- pure stdlib.
+
+```go
+limiter := porter.RateLimit(porter.RateLimitConfig{
+    Requests: 100,
+    Window:   time.Minute,
+})
+handler := limiter(mux)
+```
+
+### Per-path overrides
+
+Stricter limits for sensitive endpoints:
+
+```go
+limiter := porter.RateLimit(porter.RateLimitConfig{
+    Requests: 100,
+    Window:   time.Minute,
+    PerPath: map[string]porter.RateRule{
+        "/login": {Requests: 5, Window: time.Minute},
+        "/api/expensive": {Requests: 10, Window: time.Minute},
+    },
+})
+```
+
+### Custom key function
+
+Rate limit by something other than IP:
+
+```go
+limiter := porter.RateLimit(porter.RateLimitConfig{
+    Requests: 100,
+    Window:   time.Minute,
+    KeyFunc: func(r *http.Request) string {
+        return r.Header.Get("X-API-Key")
+    },
+})
+```
+
+### Rate limit configuration
+
+```go
+porter.RateLimit(porter.RateLimitConfig{
+    Requests:    100,                   // max requests per window (required)
+    Window:      time.Minute,           // window duration (required)
+    KeyFunc:     porter.IPKey,          // key extractor (default: IPKey)
+    PerPath:     map[string]porter.RateRule{"/login": {Requests: 5, Window: time.Minute}},
+    ExemptPaths: []string{"/health"},
+    ExemptFunc:  func(r *http.Request) bool { return r.Header.Get("X-API-Key") != "" },
+    ErrorHandler: func(w http.ResponseWriter, r *http.Request) { ... },
+})
+```
+
+## Brute Force Protection
+
+Tracks failed response status codes and blocks a key after too many failures.
+Designed for login and authentication endpoints where repeated 401 responses
+indicate a brute-force attack.
+
+```go
+brute := porter.BruteForceProtect(porter.BruteForceConfig{
+    MaxAttempts: 5,
+    Cooldown:    15 * time.Minute,
+})
+handler := brute(mux)
+```
+
+### Resetting on success
+
+Call `ResetFailures` on successful authentication so legitimate users don't get
+locked out after a few typos:
+
+```go
+mux.HandleFunc("POST /login", func(w http.ResponseWriter, r *http.Request) {
+    if authenticate(r) {
+        porter.ResetFailures(r)
+        w.WriteHeader(http.StatusOK)
+        return
+    }
+    w.WriteHeader(http.StatusUnauthorized)
+})
+```
+
+### Brute force configuration
+
+```go
+porter.BruteForceProtect(porter.BruteForceConfig{
+    MaxAttempts:   5,                    // failures before blocking (required)
+    Cooldown:      15 * time.Minute,     // block duration (required)
+    KeyFunc:       porter.IPKey,         // key extractor (default: IPKey)
+    FailureStatus: []int{401},           // status codes that count as failures (default: [401])
+    ErrorHandler:  func(w http.ResponseWriter, r *http.Request) { ... },
+})
+```
+
 ## Middleware Chain
 
 Composing middleware with nested calls works for two or three layers but
@@ -408,6 +511,11 @@ Porter tells the client three things: whether you're allowed in (authz), whether
   +---------v-------+
   |  CSRF Protect   |  validate token on unsafe methods
   |                 |  set cookie + context token
+  +---------+-------+
+            |
+  +---------v-------+
+  |   RateLimit     |  fixed-window rate limiting
+  | BruteForceProtect  track failures, block after threshold
   +---------+-------+
             |
   +---------v-------+

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 // Package porter provides authentication, authorization, CSRF protection,
-// and security header middleware for Go net/http applications.
+// rate limiting, and security header middleware for Go net/http applications.
 //
 // All middleware uses the standard func(http.Handler) http.Handler signature,
 // so it composes with any router or framework that supports net/http middleware.

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,0 +1,319 @@
+package porter
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RateLimitConfig configures the rate limiting middleware.
+type RateLimitConfig struct {
+	// Requests is the maximum number of requests allowed per window. Required.
+	Requests int
+	// Window is the duration of the rate limit window. Required.
+	Window time.Duration
+	// KeyFunc extracts a rate-limiting key from the request. When nil, IPKey is
+	// used.
+	KeyFunc func(*http.Request) string
+	// PerPath maps exact request paths to individual rate limit rules that
+	// override the default Requests/Window for those paths.
+	PerPath map[string]RateRule
+	// ExemptPaths lists exact request paths that bypass rate limiting entirely.
+	ExemptPaths []string
+	// ExemptFunc is a custom function that, when it returns true, bypasses rate
+	// limiting for the request.
+	ExemptFunc func(*http.Request) bool
+	// ErrorHandler is called when a request is rate limited. When nil, a bare
+	// 429 Too Many Requests response is written with a Retry-After header.
+	ErrorHandler func(http.ResponseWriter, *http.Request)
+}
+
+// RateRule defines a rate limit for a specific path.
+type RateRule struct {
+	// Requests is the maximum number of requests allowed per window.
+	Requests int
+	// Window is the duration of the rate limit window.
+	Window time.Duration
+}
+
+// window tracks the request count and start time for a single rate-limit key.
+type window struct {
+	count int
+	start time.Time
+}
+
+// rateLimitStore holds the internal state for rate limiting.
+type rateLimitStore struct {
+	mu      sync.Mutex
+	windows map[string]*window
+	nowFunc func() time.Time
+}
+
+// RateLimit returns middleware that enforces fixed-window rate limiting. Each
+// unique key (by default the client IP) is allowed a configured number of
+// requests per time window. Requests that exceed the limit receive a 429
+// response with a Retry-After header indicating when the window resets.
+func RateLimit(cfg RateLimitConfig) func(http.Handler) http.Handler {
+	keyFunc := cfg.KeyFunc
+	if keyFunc == nil {
+		keyFunc = IPKey
+	}
+
+	exemptSet := make(map[string]bool, len(cfg.ExemptPaths))
+	for _, p := range cfg.ExemptPaths {
+		exemptSet[p] = true
+	}
+
+	store := &rateLimitStore{
+		windows: make(map[string]*window),
+		nowFunc: time.Now,
+	}
+
+	return buildRateLimitHandler(cfg, store, exemptSet, keyFunc)
+}
+
+// buildRateLimitHandler constructs the rate limiting handler using the given
+// store. This is separated from RateLimit so tests can inject a custom nowFunc.
+func buildRateLimitHandler(cfg RateLimitConfig, store *rateLimitStore, exemptSet map[string]bool, keyFunc func(*http.Request) string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if exemptSet[r.URL.Path] {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if cfg.ExemptFunc != nil && cfg.ExemptFunc(r) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			key := keyFunc(r)
+
+			limit := cfg.Requests
+			dur := cfg.Window
+			compositeKey := key
+			if rule, ok := cfg.PerPath[r.URL.Path]; ok {
+				limit = rule.Requests
+				dur = rule.Window
+				compositeKey = key + "|" + r.URL.Path
+			}
+
+			store.mu.Lock()
+			now := store.nowFunc()
+			entry, ok := store.windows[compositeKey]
+			if !ok || now.Sub(entry.start) >= dur {
+				entry = &window{count: 0, start: now}
+				store.windows[compositeKey] = entry
+			}
+			entry.count++
+			count := entry.count
+			start := entry.start
+			store.mu.Unlock()
+
+			if count > limit {
+				remaining := dur - now.Sub(start)
+				retryAfter := int(remaining.Seconds())
+				if retryAfter < 1 {
+					retryAfter = 1
+				}
+				w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+				if cfg.ErrorHandler != nil {
+					cfg.ErrorHandler(w, r)
+					return
+				}
+				http.Error(w, "", http.StatusTooManyRequests)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// IPKey extracts the client IP address from a request. It checks
+// X-Forwarded-For first (using the first listed IP), then X-Real-IP, then
+// falls back to RemoteAddr with the port stripped.
+func IPKey(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		ip := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0])
+		if ip != "" {
+			return ip
+		}
+	}
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return strings.TrimSpace(xri)
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// BruteForceConfig configures the brute force protection middleware.
+type BruteForceConfig struct {
+	// MaxAttempts is the number of failures allowed before blocking the key.
+	// Required.
+	MaxAttempts int
+	// Cooldown is how long a key remains blocked after reaching MaxAttempts.
+	// Required.
+	Cooldown time.Duration
+	// KeyFunc extracts a tracking key from the request. When nil, IPKey is used.
+	KeyFunc func(*http.Request) string
+	// FailureStatus lists the HTTP status codes that count as failures. When
+	// nil, only 401 Unauthorized is counted.
+	FailureStatus []int
+	// ErrorHandler is called when a request is blocked. When nil, a bare 429
+	// Too Many Requests response is written with a Retry-After header.
+	ErrorHandler func(http.ResponseWriter, *http.Request)
+}
+
+// bruteForceEntry tracks failure attempts for a single key.
+type bruteForceEntry struct {
+	count     int
+	blockedAt time.Time
+}
+
+// bruteForceStore holds the internal state for brute force protection.
+type bruteForceStore struct {
+	mu      sync.Mutex
+	entries map[string]*bruteForceEntry
+	nowFunc func() time.Time
+	max     int
+	cooldown time.Duration
+}
+
+type bruteForceCtxKeyType struct{}
+
+var bruteForceCtxKey bruteForceCtxKeyType
+
+// bruteForceCtxValue is stored on the request context so that ResetFailures
+// can locate the store and key.
+type bruteForceCtxValue struct {
+	store *bruteForceStore
+	key   string
+}
+
+// bruteForceWriter intercepts WriteHeader to detect failure status codes and
+// increment the failure counter.
+type bruteForceWriter struct {
+	http.ResponseWriter
+	store        *bruteForceStore
+	key          string
+	failureSet   map[int]bool
+	once         sync.Once
+}
+
+func (bw *bruteForceWriter) WriteHeader(code int) {
+	bw.once.Do(func() {
+		if bw.failureSet[code] {
+			bw.store.mu.Lock()
+			entry, ok := bw.store.entries[bw.key]
+			if !ok {
+				entry = &bruteForceEntry{}
+				bw.store.entries[bw.key] = entry
+			}
+			entry.count++
+			if entry.count >= bw.store.max {
+				entry.blockedAt = bw.store.nowFunc()
+			}
+			bw.store.mu.Unlock()
+		}
+	})
+	bw.ResponseWriter.WriteHeader(code)
+}
+
+// BruteForceProtect returns middleware that tracks failed response status codes
+// and blocks a key after it exceeds MaxAttempts failures. The downstream
+// handler's response status is inspected via a wrapped ResponseWriter. Once
+// blocked, the key is rejected with a 429 response until the Cooldown expires.
+func BruteForceProtect(cfg BruteForceConfig) func(http.Handler) http.Handler {
+	keyFunc := cfg.KeyFunc
+	if keyFunc == nil {
+		keyFunc = IPKey
+	}
+
+	failureSet := make(map[int]bool, len(cfg.FailureStatus))
+	if len(cfg.FailureStatus) == 0 {
+		failureSet[http.StatusUnauthorized] = true
+	} else {
+		for _, code := range cfg.FailureStatus {
+			failureSet[code] = true
+		}
+	}
+
+	store := &bruteForceStore{
+		entries:  make(map[string]*bruteForceEntry),
+		nowFunc:  time.Now,
+		max:      cfg.MaxAttempts,
+		cooldown: cfg.Cooldown,
+	}
+
+	return buildBruteForceHandler(cfg, store, failureSet, keyFunc)
+}
+
+// buildBruteForceHandler constructs the brute force handler using the given
+// store. This is separated from BruteForceProtect so tests can inject a custom
+// nowFunc.
+func buildBruteForceHandler(cfg BruteForceConfig, store *bruteForceStore, failureSet map[int]bool, keyFunc func(*http.Request) string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key := keyFunc(r)
+
+			store.mu.Lock()
+			entry, ok := store.entries[key]
+			if ok && entry.count >= store.max {
+				elapsed := store.nowFunc().Sub(entry.blockedAt)
+				if elapsed < store.cooldown {
+					remaining := store.cooldown - elapsed
+					retryAfter := int(remaining.Seconds())
+					if retryAfter < 1 {
+						retryAfter = 1
+					}
+					store.mu.Unlock()
+					w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+					if cfg.ErrorHandler != nil {
+						cfg.ErrorHandler(w, r)
+						return
+					}
+					http.Error(w, "", http.StatusTooManyRequests)
+					return
+				}
+				// Cooldown expired: reset.
+				entry.count = 0
+				entry.blockedAt = time.Time{}
+			}
+			store.mu.Unlock()
+
+			// Store tracker on context so ResetFailures can clear the counter.
+			r = r.WithContext(context.WithValue(r.Context(), bruteForceCtxKey, &bruteForceCtxValue{
+				store: store,
+				key:   key,
+			}))
+
+			wrapped := &bruteForceWriter{
+				ResponseWriter: w,
+				store:          store,
+				key:            key,
+				failureSet:     failureSet,
+			}
+
+			next.ServeHTTP(wrapped, r)
+		})
+	}
+}
+
+// ResetFailures clears the failure count for the request's key. Call this on
+// successful authentication so the counter resets.
+func ResetFailures(r *http.Request) {
+	v, ok := r.Context().Value(bruteForceCtxKey).(*bruteForceCtxValue)
+	if !ok || v == nil {
+		return
+	}
+	v.store.mu.Lock()
+	delete(v.store.entries, v.key)
+	v.store.mu.Unlock()
+}

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -1,0 +1,597 @@
+package porter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// okHandler writes a 200 response.
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// statusHandler writes the given status code.
+func statusHandler(code int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+	})
+}
+
+// fakeNow returns a nowFunc and a function to advance the clock.
+func fakeNow() (func() time.Time, func(time.Duration)) {
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	return func() time.Time { return now },
+		func(d time.Duration) { now = now.Add(d) }
+}
+
+// --- RateLimit tests ---
+
+func TestRateLimit_UnderLimit_Passes(t *testing.T) {
+	mw := RateLimit(RateLimitConfig{Requests: 5, Window: time.Minute})
+	handler := mw(okHandler())
+
+	for range 5 {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+}
+
+func TestRateLimit_AtLimit_Blocks(t *testing.T) {
+	mw := RateLimit(RateLimitConfig{Requests: 2, Window: time.Minute})
+	handler := mw(okHandler())
+
+	for range 2 {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+}
+
+func TestRateLimit_RetryAfterHeader(t *testing.T) {
+	nowFn, advance := fakeNow()
+	cfg := RateLimitConfig{Requests: 1, Window: time.Minute}
+	store := &rateLimitStore{
+		windows: make(map[string]*window),
+		nowFunc: nowFn,
+	}
+
+	exemptSet := make(map[string]bool)
+	handler := buildRateLimitHandler(cfg, store, exemptSet, IPKey)(okHandler())
+
+	// First request passes.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Advance 20 seconds, second request should be blocked.
+	advance(20 * time.Second)
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Equal(t, "40", rec.Header().Get("Retry-After"))
+}
+
+func TestRateLimit_WindowResets(t *testing.T) {
+	nowFn, advance := fakeNow()
+	cfg := RateLimitConfig{Requests: 1, Window: time.Minute}
+	store := &rateLimitStore{
+		windows: make(map[string]*window),
+		nowFunc: nowFn,
+	}
+
+	exemptSet := make(map[string]bool)
+	handler := buildRateLimitHandler(cfg, store, exemptSet, IPKey)(okHandler())
+
+	// First request passes.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Second request blocked.
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+	// Advance past window, should reset.
+	advance(61 * time.Second)
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRateLimit_PerPath_Override(t *testing.T) {
+	mw := RateLimit(RateLimitConfig{
+		Requests: 10,
+		Window:   time.Minute,
+		PerPath: map[string]RateRule{
+			"/login": {Requests: 1, Window: time.Minute},
+		},
+	})
+	handler := mw(okHandler())
+
+	// First request to /login passes.
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Second request to /login blocked.
+	req = httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+	// Default path still has room.
+	req = httptest.NewRequest(http.MethodGet, "/other", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRateLimit_ExemptPaths_Bypass(t *testing.T) {
+	mw := RateLimit(RateLimitConfig{
+		Requests:    1,
+		Window:      time.Minute,
+		ExemptPaths: []string{"/health"},
+	})
+	handler := mw(okHandler())
+
+	// Exhaust limit on normal path.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Exempt path always passes.
+	for range 5 {
+		req = httptest.NewRequest(http.MethodGet, "/health", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rec = httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+}
+
+func TestRateLimit_ExemptFunc_Bypass(t *testing.T) {
+	mw := RateLimit(RateLimitConfig{
+		Requests: 1,
+		Window:   time.Minute,
+		ExemptFunc: func(r *http.Request) bool {
+			return r.Header.Get("X-API-Key") == "secret"
+		},
+	})
+	handler := mw(okHandler())
+
+	// Exhaust limit.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Without key, blocked.
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+	// With key, passes.
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-API-Key", "secret")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRateLimit_CustomErrorHandler(t *testing.T) {
+	var called bool
+	mw := RateLimit(RateLimitConfig{
+		Requests: 1,
+		Window:   time.Minute,
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("custom: rate limited"))
+		},
+	})
+	handler := mw(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.True(t, called)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Equal(t, "custom: rate limited", rec.Body.String())
+}
+
+func TestRateLimit_DefaultKeyFunc_UsesIP(t *testing.T) {
+	mw := RateLimit(RateLimitConfig{Requests: 1, Window: time.Minute})
+	handler := mw(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Same IP, different port: blocked.
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:5678"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+}
+
+func TestRateLimit_DifferentKeys_IndependentLimits(t *testing.T) {
+	mw := RateLimit(RateLimitConfig{Requests: 1, Window: time.Minute})
+	handler := mw(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Different IP: should pass independently.
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.2:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// First IP is still blocked.
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+}
+
+// --- IPKey tests ---
+
+func TestIPKey_XForwardedFor(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.1, 10.0.0.1")
+	req.RemoteAddr = "10.0.0.99:1234"
+	require.Equal(t, "203.0.113.1", IPKey(req))
+}
+
+func TestIPKey_XRealIP(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Real-IP", "198.51.100.5")
+	req.RemoteAddr = "10.0.0.99:1234"
+	require.Equal(t, "198.51.100.5", IPKey(req))
+}
+
+func TestIPKey_RemoteAddr(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "192.168.1.1:8080"
+	require.Equal(t, "192.168.1.1", IPKey(req))
+}
+
+// --- BruteForceProtect tests ---
+
+func TestBruteForceProtect_UnderThreshold_Passes(t *testing.T) {
+	mw := BruteForceProtect(BruteForceConfig{
+		MaxAttempts: 3,
+		Cooldown:    time.Minute,
+	})
+	handler := mw(statusHandler(http.StatusUnauthorized))
+
+	// Two failures should not block.
+	for range 2 {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	}
+
+	// Third attempt still reaches the handler (failure is counted on response).
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestBruteForceProtect_AtThreshold_Blocks(t *testing.T) {
+	mw := BruteForceProtect(BruteForceConfig{
+		MaxAttempts: 2,
+		Cooldown:    time.Minute,
+	})
+	handler := mw(statusHandler(http.StatusUnauthorized))
+
+	// Trigger 2 failures.
+	for range 2 {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	}
+
+	// Next request should be blocked before reaching handler.
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+}
+
+func TestBruteForceProtect_CooldownExpires_Unblocks(t *testing.T) {
+	nowFn, advance := fakeNow()
+	cfg := BruteForceConfig{
+		MaxAttempts: 1,
+		Cooldown:    time.Minute,
+	}
+
+	store := &bruteForceStore{
+		entries:  make(map[string]*bruteForceEntry),
+		nowFunc:  nowFn,
+		max:      cfg.MaxAttempts,
+		cooldown: cfg.Cooldown,
+	}
+
+	handler := buildBruteForceHandler(cfg, store, map[int]bool{http.StatusUnauthorized: true}, IPKey)(statusHandler(http.StatusUnauthorized))
+
+	// One failure triggers block.
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// Blocked.
+	req = httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+	// Advance past cooldown.
+	advance(61 * time.Second)
+	req = httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestBruteForceProtect_SuccessDoesNotCount(t *testing.T) {
+	mw := BruteForceProtect(BruteForceConfig{
+		MaxAttempts: 2,
+		Cooldown:    time.Minute,
+	})
+	handler := mw(statusHandler(http.StatusOK))
+
+	// 200 responses should not count as failures.
+	for range 5 {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+}
+
+func TestBruteForceProtect_CustomFailureStatus(t *testing.T) {
+	mw := BruteForceProtect(BruteForceConfig{
+		MaxAttempts:   1,
+		Cooldown:      time.Minute,
+		FailureStatus: []int{http.StatusForbidden},
+	})
+	handler := mw(statusHandler(http.StatusForbidden))
+
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+
+	// Should be blocked now.
+	req = httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+}
+
+func TestBruteForceProtect_CustomErrorHandler(t *testing.T) {
+	var called bool
+	mw := BruteForceProtect(BruteForceConfig{
+		MaxAttempts: 1,
+		Cooldown:    time.Minute,
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("custom: blocked"))
+		},
+	})
+	handler := mw(statusHandler(http.StatusUnauthorized))
+
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	req = httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.True(t, called)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Equal(t, "custom: blocked", rec.Body.String())
+}
+
+func TestBruteForceProtect_RetryAfterHeader(t *testing.T) {
+	nowFn, advance := fakeNow()
+	cfg := BruteForceConfig{
+		MaxAttempts: 1,
+		Cooldown:    time.Minute,
+	}
+
+	store := &bruteForceStore{
+		entries:  make(map[string]*bruteForceEntry),
+		nowFunc:  nowFn,
+		max:      cfg.MaxAttempts,
+		cooldown: cfg.Cooldown,
+	}
+
+	handler := buildBruteForceHandler(cfg, store, map[int]bool{http.StatusUnauthorized: true}, IPKey)(statusHandler(http.StatusUnauthorized))
+
+	// One failure.
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// Advance 15 seconds, then check Retry-After.
+	advance(15 * time.Second)
+	req = httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Equal(t, "45", rec.Header().Get("Retry-After"))
+}
+
+func TestResetFailures_ClearsCounter(t *testing.T) {
+	mw := BruteForceProtect(BruteForceConfig{
+		MaxAttempts: 2,
+		Cooldown:    time.Minute,
+	})
+
+	// Handler that returns 401, but on the third call, returns 200 and resets.
+	callCount := 0
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 3 {
+			ResetFailures(r)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	handler := mw(inner)
+
+	// Two failures.
+	for range 2 {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	}
+
+	// Blocked.
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+	// Hmm, we need to test ResetFailures differently since we're blocked.
+	// Reset callCount and test with a flow that resets before blocking.
+	callCount = 0
+
+	// Use a fresh middleware instance.
+	mw2 := BruteForceProtect(BruteForceConfig{
+		MaxAttempts: 3,
+		Cooldown:    time.Minute,
+	})
+	callCount2 := 0
+	inner2 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount2++
+		if callCount2 == 2 {
+			// Successful login: reset counter.
+			ResetFailures(r)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	handler2 := mw2(inner2)
+
+	// First attempt: failure.
+	req = httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler2.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// Second attempt: success + reset.
+	req = httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler2.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Third and fourth: two more failures should be fine (counter was reset).
+	for range 2 {
+		req = httptest.NewRequest(http.MethodPost, "/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rec = httptest.NewRecorder()
+		handler2.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	}
+
+	// Fifth: would be the 3rd failure post-reset, so still not blocked
+	// (reaches handler but triggers block).
+	req = httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler2.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// Sixth: now blocked.
+	req = httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler2.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+}


### PR DESCRIPTION
## Summary

- Add `RateLimit` middleware with fixed-window rate limiting, per-path overrides, exemptions, and custom key functions
- Add `BruteForceProtect` middleware that tracks failed response status codes and blocks keys after exceeding a threshold
- Add `IPKey` helper for extracting client IP from X-Forwarded-For, X-Real-IP, or RemoteAddr
- Add `ResetFailures` helper to clear brute force counters on successful authentication
- Comprehensive tests for both middlewares with fake clock injection for time-dependent behavior

Closes #44